### PR TITLE
Refactor redirect process

### DIFF
--- a/lib/rack/joint/context.rb
+++ b/lib/rack/joint/context.rb
@@ -1,8 +1,9 @@
 module Rack
   class Joint
     class Context
-      attr_reader :responses
-      def initialize
+      attr_reader :request, :responses
+      def initialize(request)
+        @request = request
         @responses = []
       end
 
@@ -11,7 +12,7 @@ module Rack
       # @return [Array] Return Array consisted of block under `redirect`.
       def host(old_host, &block)
         responses << {
-          "#{old_host}" => Redirect.new(old_host).instance_exec(&block)
+          "#{old_host}" => Redirect.new(request, old_host).instance_exec(&block)
         }
       end
     end

--- a/lib/rack/joint/redirect.rb
+++ b/lib/rack/joint/redirect.rb
@@ -3,10 +3,10 @@
 module Rack
   class Joint
     class Redirect
-      attr_reader :responses
-      attr_reader :old_host
-      def initialize(old_host)
+      attr_reader :responses, :request, :old_host
+      def initialize(request, old_host)
         @responses = []
+        @request = request
         @old_host = old_host
       end
 
@@ -14,7 +14,7 @@ module Rack
       # @param &block [block] Given block with `redirect`.
       # @return [Array] Return Array consisted of block under `redirect`.
       def redirect(old_path, &block)
-        responses << RedirectInterface.new(old_host, old_path, &block).apply!
+        responses << RedirectInterface.new(request, old_host, old_path, &block).apply!
       end
     end
   end

--- a/test/config/set_get_https_config.ru
+++ b/test/config/set_get_https_config.ru
@@ -1,0 +1,13 @@
+require 'rack/joint'
+
+use Rack::Joint do
+  host 'example.com' do
+    redirect '/foo/bar/baz' do
+      ssl true
+      new_host 'example.org'
+      to '/path/to/blah'
+    end
+  end
+end
+
+run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['Hello World!']] }

--- a/test/rack/joint_test.rb
+++ b/test/rack/joint_test.rb
@@ -14,6 +14,7 @@ class JointTest < MiniTest::Test
       get '/foo/bar/baz', {}, 'HTTP_HOST' => 'example.com'
       assert_equal 301, last_response.status
       assert_equal 'http://example.org/path/to/blah', last_response['location']
+      assert_equal 'Redirect from: http://example.com/foo/bar/baz', last_response.body
     end
   end
 
@@ -26,14 +27,17 @@ class JointTest < MiniTest::Test
       get '/dogs/bark.html', {}, 'HTTP_HOST' => 'example.com'
       assert_equal 301, last_response.status
       assert_equal 'http://example.org/bowwow/woof', last_response['location']
+      assert_equal 'Redirect from: http://example.com/dogs/bark.html', last_response.body
 
       get '/cats/meow.html', {}, 'HTTP_HOST' => 'example.com'
       assert_equal 302, last_response.status
       assert_equal 'http://example.org/meow/meow/mew', last_response['location']
+      assert_equal 'Redirect from: http://example.com/cats/meow.html', last_response.body
 
       get '/frog.html', {}, 'HTTP_HOST' => 'example.com'
       assert_equal 301, last_response.status
       assert_equal 'http://example.org/croak', last_response['location']
+      assert_equal 'Redirect from: http://example.com/frog.html', last_response.body
     end
   end
 
@@ -46,10 +50,12 @@ class JointTest < MiniTest::Test
       get '/dogs/bark.html', {}, 'HTTP_HOST' => 'example.net'
       assert_equal 301, last_response.status
       assert_equal 'http://example.org/bowwow/woof', last_response['location']
+      assert_equal 'Redirect from: http://example.net/dogs/bark.html', last_response.body
 
       get '/cats/meow.html', {}, 'HTTP_HOST' => 'example.com'
       assert_equal 301, last_response.status
       assert_equal 'http://example.org/meow/meow/mew', last_response['location']
+      assert_equal 'Redirect from: http://example.com/cats/meow.html', last_response.body
     end
   end
 
@@ -62,10 +68,12 @@ class JointTest < MiniTest::Test
       get '/dogs/bark.html', {}, 'HTTP_HOST' => 'example.com'
       assert_equal 301, last_response.status
       assert_equal 'http://example.com/bowwow/woof', last_response['location']
+      assert_equal 'Redirect from: http://example.com/dogs/bark.html', last_response.body
 
       get '/cats/meow.html', {}, 'HTTP_HOST' => 'example.com'
       assert_equal 302, last_response.status
       assert_equal 'http://example.com/meow/meow/mew', last_response['location']
+      assert_equal 'Redirect from: http://example.com/cats/meow.html', last_response.body
     end
   end
 
@@ -78,13 +86,18 @@ class JointTest < MiniTest::Test
       get '/foo', {}, 'HTTP_HOST' => 'example.com'
       assert_equal 301, last_response.status
       assert_equal 'http://example.org/foo', last_response['location']
+      assert_equal 'Redirect from: http://example.com/foo', last_response.body
     end
   end
 
   class SetSameURLTest < JointTest
+    def app
+      same_url_config
+    end
+
     def test_joint
       assert_raises Rack::Joint::BadRedirectError do
-        same_url_config
+        get '/foo/bar/baz', {}, 'HTTP_HOST' => 'example.com'
       end
     end
   end
@@ -100,7 +113,7 @@ class JointTest < MiniTest::Test
     end
   end
 
-  class HostWithSSlTest < JointTest
+  class HostWithSSLTest < JointTest
     def app
       hosts_with_ssl_config
     end
@@ -109,10 +122,25 @@ class JointTest < MiniTest::Test
       get '/dogs/bark.html', {}, 'HTTP_HOST' => 'example.com'
       assert_equal 301, last_response.status
       assert_equal 'https://example.org/bowwow/woof', last_response['location']
+      assert_equal 'Redirect from: http://example.com/dogs/bark.html', last_response.body
 
       get '/cats/meow.html', {}, 'HTTP_HOST' => 'example.com'
       assert_equal 301, last_response.status
       assert_equal 'http://example.org/meow/meow/mew', last_response['location']
+      assert_equal 'Redirect from: http://example.com/cats/meow.html', last_response.body
+    end
+  end
+
+  class AccessWithSSLHostTest < JointTest
+    def app
+      get_url_with_ssl_config
+    end
+
+    def test_joint
+      get '/foo/bar/baz', {}, 'HTTP_HOST' => 'example.com', 'HTTPS' => 'on'
+      assert_equal 301, last_response.status
+      assert_equal 'https://example.org/path/to/blah', last_response['location']
+      assert_equal 'Redirect from: https://example.com/foo/bar/baz', last_response.body
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,3 +30,7 @@ def hosts_with_ssl_config
   Rack::Builder.parse_file('test/config/set_hosts_with_ssl_config.ru').first
 end
 
+def get_url_with_ssl_config
+  Rack::Builder.parse_file('test/config/set_get_https_config.ru').first
+end
+


### PR DESCRIPTION
This is refactoring.
Until now, mapping URL to redirect before receiving requests. However, it changed to make URL map after request.

Furthermore, it has enabled to receive `https` requests.