### PR TITLE
Determine scheme in response to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ You can use following resources with block.
 | :------- | :--- | :---------- |
 | `host`   | String | Host name. |
 | `redirect` | String | Path name. |
-| `ssl` | Boolean | Whether to enable SSL or not; which is `false` to default. |
-| `new_host` | String | A new host name redirects to. Optional. |
-| `to` | String | A new path name redirects to. Optional. |
+| `ssl` | Boolean | Whether to enable SSL. If the option isn't set, the scheme of `Location` header is determined in response to GET request. |
+| `new_host` | String | A new host name redirects to. |
+| `to` | String | A new path name redirects to. |
 | `status` | Integer | Status when redirecting. You can use `301`, `302`, `303`, `307`, `308`; which is `301` to default. |
 
 ## Development

--- a/lib/rack/joint/redirect_interface.rb
+++ b/lib/rack/joint/redirect_interface.rb
@@ -6,22 +6,23 @@ module Rack
     class BadRedirectError < StandardError; end
 
     class RedirectInterface
-      attr_reader :request, :old_host, :old_path, :old_url
+      attr_reader :scheme, :request_scheme, :old_host, :old_path, :old_url
       def initialize(request, old_host, old_path, &block)
         @status = 301
-        @ssl = false
-        @request = request
+        @scheme = nil
+        @request_scheme = request.scheme
         @old_host = old_host
         @old_path = old_path
-        @old_url = build_uri(request.scheme, old_host, old_path)
+        @old_url = build_uri(request_scheme, old_host, old_path)
         instance_exec(&block)
       end
 
       # @return [Array] Return response given parameters in `config.ru`.
       def apply!
+        @scheme ||= request_scheme
         @new_host ||= old_host
         @new_path ||= old_path
-        new_location = build_uri(uri_scheme, @new_host, @new_path)
+        new_location = build_uri(scheme, @new_host, @new_path)
         if old_url == new_location
           raise BadRedirectError.new('Redirect URL has been declared the same as current URL.')
         end
@@ -29,15 +30,6 @@ module Rack
       end
 
       private
-
-      # @return [String] `http` or `https`
-      def uri_scheme
-        if @ssl
-          'https'
-        else
-          'http'
-        end
-      end
 
       # @param scheme [String] 'http' or 'https'
       # @param host [String] Host name
@@ -51,10 +43,15 @@ module Rack
         end
       end
 
-      # @param scheme [Boolean] Wether enabling SSL or not.
-      # @return [Boolean]
-      def ssl(scheme)
-        @ssl = scheme
+      # @param flag [Boolean]
+      # @return [String] `http` or `https`
+      def ssl(flag)
+        @scheme =
+          if flag
+            'https'
+          else
+            'http'
+          end
       end
 
       # @param status [Integer] `status` parameter when redirecting in `config.ru`.

--- a/test/config/set_get_https_config.ru
+++ b/test/config/set_get_https_config.ru
@@ -7,6 +7,17 @@ use Rack::Joint do
       new_host 'example.org'
       to '/path/to/blah'
     end
+
+    redirect '/dogs/bark.html' do
+      ssl false
+      new_host 'example.org'
+      to '/bowwow'
+    end
+
+    redirect '/cats/meow.html' do
+      new_host 'example.org'
+      to '/meow'
+    end
   end
 end
 

--- a/test/rack/joint_test.rb
+++ b/test/rack/joint_test.rb
@@ -141,6 +141,16 @@ class JointTest < MiniTest::Test
       assert_equal 301, last_response.status
       assert_equal 'https://example.org/path/to/blah', last_response['location']
       assert_equal 'Redirect from: https://example.com/foo/bar/baz', last_response.body
+
+      get '/dogs/bark.html', {}, 'HTTP_HOST' => 'example.com', 'HTTPS' => 'on'
+      assert_equal 301, last_response.status
+      assert_equal 'http://example.org/bowwow', last_response['location']
+      assert_equal 'Redirect from: https://example.com/dogs/bark.html', last_response.body
+
+      get '/cats/meow.html', {}, 'HTTP_HOST' => 'example.com', 'HTTPS' => 'on'
+      assert_equal 301, last_response.status
+      assert_equal 'https://example.org/meow', last_response['location']
+      assert_equal 'Redirect from: https://example.com/cats/meow.html', last_response.body
     end
   end
 end


### PR DESCRIPTION
It changed default behavior when `ssl` option wasn't set.

If GET request with `http`, 'Location' header when redirecting will be
`http`. And if with `https`, 'Location' will be `https`.