### PR TITLE
Host based redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ use Rack::Joint do
       new_host 'example.org'
     end
   end
+
+  # Following description allows you to redirect to URL you set with only host replaced.
+  #
+  # e.g. When accessing 'http://example.io/foo/bar/baz',
+  #      redirect to `http://example.org/foob/bar/baz` with 301.
+  host 'example.io' do
+    redirect do
+      new_host 'example.org'
+    end
+  end
 end
 
 run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['Hello World!']] }
@@ -71,12 +81,12 @@ You can use following resources with block.
 
 | Resource | Type | Description |
 | :------- | :--- | :---------- |
-| `host`   | String | Host name. |
-| `redirect` | String | Path name. |
-| `ssl` | Boolean | Whether to enable SSL. If the option isn't set, the scheme of `Location` header is determined in response to GET request. |
-| `new_host` | String | A new host name redirects to. |
-| `to` | String | A new path name redirects to. |
-| `status` | Integer | Status when redirecting. You can use `301`, `302`, `303`, `307`, `308`; which is `301` to default. |
+| `host`   | `string` | Required. Host name. |
+| `redirect` | `string` | Path name. If you give nothing with this option, Rack::Joint will replace only host name. |
+| `ssl` | `boolean` | Whether to enable SSL. If the option isn't set, the scheme of `Location` header is determined in response to GET request. |
+| `new_host` | `string` | A new host name redirects to. |
+| `to` | `string` | A new path name redirects to. |
+| `status` | `integer` | Status when redirecting. You can use `301`, `302`, `303`, `307`, `308`; which is `301` to default. |
 
 ## Development
 

--- a/lib/rack/joint/redirect.rb
+++ b/lib/rack/joint/redirect.rb
@@ -13,7 +13,7 @@ module Rack
       # @param old_path [String] Path set as argument in `config.ru`.
       # @param &block [block] Given block with `redirect`.
       # @return [Array] Return Array consisted of block under `redirect`.
-      def redirect(old_path, &block)
+      def redirect(old_path = nil, &block)
         responses << RedirectInterface.new(request, old_host, old_path, &block).apply!
       end
     end

--- a/lib/rack/joint/redirect_interface.rb
+++ b/lib/rack/joint/redirect_interface.rb
@@ -6,14 +6,13 @@ module Rack
     class BadRedirectError < StandardError; end
 
     class RedirectInterface
-      attr_reader :scheme, :request_scheme, :old_host, :old_path, :old_url
+      attr_reader :scheme, :request_scheme, :old_host, :old_path
       def initialize(request, old_host, old_path, &block)
         @status = 301
         @scheme = nil
         @request_scheme = request.scheme
         @old_host = old_host
-        @old_path = old_path
-        @old_url = build_uri(request_scheme, old_host, old_path)
+        @old_path = old_path || request.path_info
         instance_exec(&block)
       end
 
@@ -22,6 +21,7 @@ module Rack
         @scheme ||= request_scheme
         @new_host ||= old_host
         @new_path ||= old_path
+        old_url = build_uri(request_scheme, old_host, old_path)
         new_location = build_uri(scheme, @new_host, @new_path)
         if old_url == new_location
           raise BadRedirectError.new('Redirect URL has been declared the same as current URL.')

--- a/test/config/set_redirect_all_paths_config.ru
+++ b/test/config/set_redirect_all_paths_config.ru
@@ -1,0 +1,11 @@
+require 'rack/joint'
+
+use Rack::Joint do
+  host 'example.com' do
+    redirect do
+      new_host 'example.org'
+    end
+  end
+end
+
+run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['Hello World!']] }

--- a/test/rack/joint_test.rb
+++ b/test/rack/joint_test.rb
@@ -153,4 +153,23 @@ class JointTest < MiniTest::Test
       assert_equal 'Redirect from: https://example.com/cats/meow.html', last_response.body
     end
   end
+
+
+  class RedirectAllPathsTest < JointTest
+    def app
+      redirect_all_paths
+    end
+
+    def test_joint
+      get '/cats/meow.html', {}, 'HTTP_HOST' => 'example.com', 'HTTPS' => 'on'
+      assert_equal 301, last_response.status
+      assert_equal 'https://example.org/cats/meow.html', last_response['location']
+      assert_equal 'Redirect from: https://example.com/cats/meow.html', last_response.body
+
+      get '/dogs/bow', {}, 'HTTP_HOST' => 'example.com', 'HTTPS' => 'on'
+      assert_equal 301, last_response.status
+      assert_equal 'https://example.org/dogs/bow', last_response['location']
+      assert_equal 'Redirect from: https://example.com/dogs/bow', last_response.body
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,3 +34,6 @@ def get_url_with_ssl_config
   Rack::Builder.parse_file('test/config/set_get_https_config.ru').first
 end
 
+def redirect_all_paths
+  Rack::Builder.parse_file('test/config/set_redirect_all_paths_config.ru').first
+end


### PR DESCRIPTION
This application has required the original path when writing redirect settings
in `config.ru`.
However, it has a problem that we cannot have replaced the only host because
the app has presumed to redirect with **each** path.

Therefore, this change allows redirecting each host.