### PR TITLE
Allow query parameters for request URLs

### DIFF
--- a/lib/rack/joint.rb
+++ b/lib/rack/joint.rb
@@ -2,6 +2,7 @@ require "rack"
 require "rack/joint/context"
 require "rack/joint/redirect"
 require "rack/joint/redirect_interface"
+require "rack/joint/url_builder"
 require "rack/joint/version"
 
 module Rack
@@ -27,7 +28,7 @@ module Rack
 
     private
 
-    # @param mapping [Array] URI mappings for redirecting.
+    # @param mappings [Array] URI mappings for redirecting.
     # @param host    [String] Requested hostname(env).
     # @return [Array] Return URL mapped responses.
     def valid_mapping(mappings, host)

--- a/lib/rack/joint/url_builder.rb
+++ b/lib/rack/joint/url_builder.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'uri'
+
+module Rack
+  class Joint
+    class UrlBuilder
+      attr_reader :scheme, :query, :host, :path
+      def initialize(scheme, request_query, host, path)
+        @scheme = scheme
+        @query = request_query
+        @host = host
+        @path = path
+      end
+
+      # @return [URI] URL with SSL or non-SSL
+      def build
+        if scheme == 'https'
+          https_url_builder
+        else
+          http_url_builder
+        end
+      end
+
+      private
+
+      # @return [URI]
+      def https_url_builder
+        # When query parameters isn't added to request URL,
+        # returns empty String object with `Rack::Request::Helper#query_string`.
+        if query.empty?
+          URI::HTTPS.build({ host: host, path: path }).to_s
+        else
+          URI::HTTPS.build({ host: host, path: path, query: query }).to_s
+        end
+      end
+
+      # @return [URI]
+      def http_url_builder
+        # When query parameters isn't added to request URL,
+        # returns empty String object with `Rack::Request::Helper#query_string`.
+        if query.empty?
+          URI::HTTP.build({ host: host, path: path }).to_s
+        else
+          URI::HTTP.build({ host: host, path: path, query: query }).to_s
+        end
+      end
+    end
+  end
+end

--- a/test/rack/joint_test.rb
+++ b/test/rack/joint_test.rb
@@ -136,7 +136,6 @@ class JointTest < MiniTest::Test
     end
   end
 
-
   class RedirectAllPathsTest < JointTest
     def app
       redirect_all_paths
@@ -152,6 +151,19 @@ class JointTest < MiniTest::Test
       assert_equal 301, last_response.status
       assert_equal 'https://example.org/dogs/bow', last_response['location']
       assert_equal 'Redirect from: https://example.com/dogs/bow', last_response.body
+    end
+  end
+
+  class RedirectWithQueryParameters < JointTest
+    def app
+      only_host_config
+    end
+
+    def test_joint
+      get '/foo?hoge=abcdef&fuga=ghijkl', {}, 'HTTP_HOST' => 'example.com', 'HTTPS' => 'on'
+      assert_equal 301, last_response.status
+      assert_equal 'https://example.org/foo?hoge=abcdef&fuga=ghijkl', last_response['location']
+      assert_equal 'Redirect from: https://example.com/foo?hoge=abcdef&fuga=ghijkl', last_response.body
     end
   end
 end


### PR DESCRIPTION
closes #17 

This change allows adding query parameters when a request URL has ones.
Before this commit, if the URL requested, redirected URL strings have not had request parameters, for instance, if `http://foo.com/bar?baz=abc` was requested, rendered URL is `http://foo.com/fuga`.